### PR TITLE
convert to futures 0.3 (alpha)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ Timeouts and intervals for futures.
 
 [dependencies]
 futures-preview = "0.3.0-alpha.7"
+pin-utils = "0.1.0-alpha.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "futures-timer"
 version = "0.1.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/alexcrichton/futures-timer"
@@ -12,4 +13,4 @@ Timeouts and intervals for futures.
 """
 
 [dependencies]
-futures = "0.2"
+futures-preview = "0.3.0-alpha.7"

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -144,11 +144,11 @@ impl Future for Delay {
     fn poll(self: Pin<&mut Self>, lw: &task::LocalWaker) -> Poll<Self::Output> {
         let state = match self.state {
             Some(ref state) => state,
-            None => return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other,
-                                              "timer has gone away"))),
+            None => return Err(io::Error::new(io::ErrorKind::Other,
+                                              "timer has gone away")).into(),
         };
         if state.state.load(SeqCst) & 1 != 0 {
-            return Poll::Ready(Ok(()))
+            return Ok(()).into()
         }
 
         state.waker.register(lw);
@@ -157,9 +157,9 @@ impl Future for Delay {
         // state. If we've fired the first bit is set, and if we've been
         // invalidated the second bit is set.
         match state.state.load(SeqCst) {
-            n if n & 0b01 != 0 => Poll::Ready(Ok(())),
-            n if n & 0b10 != 0 => Poll::Ready(Err(io::Error::new(io::ErrorKind::Other,
-                                                     "timer has gone away"))),
+            n if n & 0b01 != 0 => Ok(()).into(),
+            n if n & 0b10 != 0 => Err(io::Error::new(io::ErrorKind::Other,
+                                                     "timer has gone away")).into(),
             _ => Poll::Pending,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,10 @@
 
 #![feature(futures_api, pin, arbitrary_self_types, try_trait)]
 #![deny(missing_docs)]
+#![feature(core_intrinsics)]
 
 extern crate futures;
+#[macro_use] extern crate pin_utils;
 
 use std::cmp::Ordering;
 use std::mem;

--- a/tests/interval.rs
+++ b/tests/interval.rs
@@ -12,7 +12,7 @@ fn single() {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
     let interval = Interval::new(dur);
-    block_on(interval.take(1).collect::<Vec<_>>()).unwrap();
+    block_on(interval.take(1).collect::<Vec<_>>());
     assert!(start.elapsed() >= dur);
 }
 
@@ -21,7 +21,8 @@ fn two_times() {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
     let interval = Interval::new(dur);
-    let result = block_on(interval.take(2).collect::<Vec<_>>()).unwrap();
+    let result = block_on(interval.take(2).collect::<Vec<_>>())
+        .into_iter().collect::<Result<Vec<_>, _>>().unwrap();
     assert!(start.elapsed() >= dur*2);
     assert_eq!(result, vec![(), ()]);
 }


### PR DESCRIPTION
I tried the latest version of futures (0.3.0-alpha.7).
futures 0.3 is currently in progress so this pr might be broken when the stable version is released.
I hope it will be helpful.
