### PR TITLE
Futures 03

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 
 matrix:
   include:
-    - rust: stable
-    - rust: beta
+    # - rust: stable
+    # - rust: beta
     - rust: nightly
       before_script:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "futures-timer"
 version = "0.1.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/alexcrichton/futures-timer"
@@ -12,4 +13,4 @@ Timeouts and intervals for futures.
 """
 
 [dependencies]
-futures = "0.1.15"
+futures-preview = "0.3.0-alpha.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ Timeouts and intervals for futures.
 [dependencies]
 futures-preview = "0.3.0-alpha.16"
 pin-utils = "0.1.0-alpha.4"
+
+[dev-dependencies]
+runtime = "0.3.0-alpha.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ Timeouts and intervals for futures.
 
 [dependencies]
 futures-preview = "0.3.0-alpha.16"
+pin-utils = "0.1.0-alpha.4"

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ use std::time::Duration;
 use futures::prelude::*;
 use futures_timer::Delay;
 
-fn main() {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Delay::new(Duration::from_secs(3))
-      .map(|()| println!("printed after three seconds"))
-      .wait()
-      .unwrap();
+        .map(|()| println!("printed after three seconds"))
+        .await?;
 }
 ```
 
@@ -37,12 +36,12 @@ use std::time::Duration;
 use futures::prelude::*;
 use futures_timer::Interval;
 
-fn main() {
+#[runtime::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Interval::new(Duration::from_secs(4))
-      .take(4)
-      .for_each(|()| Ok(println!("printed after three seconds")))
-      .wait()
-      .unwrap();
+        .take(4)
+        .for_each(|()| Ok(println!("printed after three seconds")))
+        .await?;
 }
 ```
 
@@ -53,7 +52,7 @@ use std::time::Duration;
 
 use futures_timer::FutureExt;
 
-fn main() {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // create a future that will take at most 3 seconds to resolve
     let future = long_running_future()
       .timeout(Duration::from_secs(3));

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ futures-timer = "0.1"
 An example of using a `Delay` is:
 
 ```rust
-extern crate futures;
-extern crate futures_timer;
-
 use std::time::Duration;
 
 use futures::prelude::*;
@@ -35,9 +32,6 @@ fn main() {
 And using an `Interval`:
 
 ```rust
-extern crate futures;
-extern crate futures_timer;
-
 use std::time::Duration;
 
 use futures::prelude::*;
@@ -55,8 +49,6 @@ fn main() {
 Or timing out a future
 
 ```rust
-extern crate futures_timer;
-
 use std::time::Duration;
 
 use futures_timer::FutureExt;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -3,13 +3,13 @@
 //! This module contains the `Delay` type which is a future that will resolve
 //! at a particular point in the future.
 
-use std::futures::Future;
+use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex};
-use std::task::Poll;
+use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use futures::task::AtomicTask;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -155,7 +155,7 @@ pub fn fires_at(timeout: &Delay) -> Instant {
 impl Future for Delay {
     type Output = io::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let state = match self.state {
             Some(ref state) => state,
             None => {

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -35,6 +35,7 @@ impl Delay {
     ///
     /// The returned object will be bound to the default timer for this thread.
     /// The default timer will be spun up in a helper thread on first use.
+    #[inline]
     pub fn new(dur: Duration) -> Delay {
         Delay::new_at(Instant::now() + dur)
     }
@@ -43,6 +44,7 @@ impl Delay {
     ///
     /// The returned object will be bound to the default timer for this thread.
     /// The default timer will be spun up in a helper thread on first use.
+    #[inline]
     pub fn new_at(at: Instant) -> Delay {
         Delay::new_handle(at, Default::default())
     }
@@ -90,6 +92,7 @@ impl Delay {
     /// specified by `dur`.
     ///
     /// This is equivalent to calling `reset_at` with `Instant::now() + dur`
+    #[inline]
     pub fn reset(&mut self, dur: Duration) {
         self.reset_at(Instant::now() + dur)
     }
@@ -107,6 +110,7 @@ impl Delay {
     /// Note that if any task is currently blocked on this future then that task
     /// will be dropped. It is required to call `poll` again after this method
     /// has been called to ensure tha ta task is blocked on this future.
+    #[inline]
     pub fn reset_at(&mut self, at: Instant) {
         self.when = at;
         if self._reset(at).is_err() {
@@ -143,6 +147,7 @@ impl Delay {
     }
 }
 
+#[inline]
 pub fn fires_at(timeout: &Delay) -> Instant {
     timeout.when
 }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,161 +1,167 @@
-//! Extension traits for the standard `Stream` and `Future` traits.
+////! Extension traits for the standard `Stream` and `Future` traits.
 
-use std::time::{Duration, Instant};
-use std::io;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+//use std::time::{Duration, Instant};
+//use std::io;
+//use std::pin::Pin;
+//use std::task::{Context, Poll};
+//use pin_utils::unsafe_pinned;
 
-use futures::prelude::*;
+//use futures::prelude::*;
 
-use crate::Delay;
+//use crate::Delay;
 
-/// An extension trait for futures which provides convenient accessors for
-/// timing out execution and such.
-pub trait FutureExt: TryFuture + Sized {
-    /// Creates a new future which will take at most `dur` time to resolve from
-    /// the point at which this method is called.
-    ///
-    /// This combinator creates a new future which wraps the receiving future
-    /// in a timeout. The future returned will resolve in at most `dur` time
-    /// specified (relative to when this function is called).
-    ///
-    /// If the future completes before `dur` elapses then the future will
-    /// resolve with that item. Otherwise the future will resolve to an error
-    /// once `dur` has elapsed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// extern crate futures;
-    /// extern crate futures_timer;
-    ///
-    /// use std::time::Duration;
-    /// use futures::prelude::*;
-    /// use futures_timer::FutureExt;
-    ///
-    /// # fn long_future() -> futures::future::FutureResult<(), std::io::Error> {
-    /// #   futures::future::ok(())
-    /// # }
-    /// #
-    /// fn main() {
-    ///     let future = long_future();
-    ///     let timed_out = future.timeout(Duration::from_secs(1));
-    ///
-    ///     match timed_out.wait() {
-    ///         Ok(item) => println!("got {:?} within enough time!", item),
-    ///         Err(_) => println!("took too long to produce the item"),
-    ///     }
-    /// }
-    /// ```
-    fn timeout(self, dur: Duration) -> Timeout<Self>
-        where Self::Error: From<io::Error>,
-    {
-        Timeout {
-            timeout: Delay::new(dur),
-            future: self,
-        }
-    }
-
-    /// Creates a new future which will resolve no later than `at` specified.
-    ///
-    /// This method is otherwise equivalent to the `timeout` method except that
-    /// it tweaks the moment at when the timeout elapsed to being specified with
-    /// an absolute value rather than a relative one. For more documentation see
-    /// the `timeout` method.
-    fn timeout_at(self, at: Instant) -> Timeout<Self>
-        where Self::Error: From<io::Error>,
-    {
-        Timeout {
-            timeout: Delay::new_at(at),
-            future: self,
-        }
-    }
-}
-
-impl<F: Future> FutureExt for F {}
-
-/// Future returned by the `FutureExt::timeout` method.
-pub struct Timeout<F> {
-    timeout: Delay,
-    future: F,
-}
-
-impl<F> Future for Timeout<F>
-    where F: TryFuture,
-          F::Error: From<io::Error>,
-{
-    type Output = Result<F::Ok, F::Error>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.future.poll()? {
-            Poll::Pending => {}
-            other => return Ok(other)
-        }
-
-        if self.timeout.poll()?.is_ready() {
-            Err(io::Error::new(io::ErrorKind::TimedOut, "future timed out").into())
-        } else {
-            Ok(Poll::Pending)
-        }
-    }
-}
-
-///// An extension trait for streams which provides convenient accessors for
+///// An extension trait for futures which provides convenient accessors for
 ///// timing out execution and such.
-//pub trait StreamExt: Stream + Sized {
-
-//    /// Creates a new stream which will take at most `dur` time to yield each
-//    /// item of the stream.
+//pub trait FutureExt: TryFuture + Sized {
+//    /// Creates a new future which will take at most `dur` time to resolve from
+//    /// the point at which this method is called.
 //    ///
-//    /// This combinator creates a new stream which wraps the receiving stream
-//    /// in a timeout-per-item. The stream returned will resolve in at most
-//    /// `dur` time for each item yielded from the stream. The first item's timer
-//    /// starts when this method is called.
+//    /// This combinator creates a new future which wraps the receiving future
+//    /// in a timeout. The future returned will resolve in at most `dur` time
+//    /// specified (relative to when this function is called).
 //    ///
-//    /// If a stream's item completes before `dur` elapses then the timer will be
-//    /// reset for the next item. If the timeout elapses, however, then an error
-//    /// will be yielded on the stream and the timer will be reset.
-//    fn timeout(self, dur: Duration) -> TimeoutStream<Self>
+//    /// If the future completes before `dur` elapses then the future will
+//    /// resolve with that item. Otherwise the future will resolve to an error
+//    /// once `dur` has elapsed.
+//    ///
+//    /// # Examples
+//    ///
+//    /// ```
+//    /// extern crate futures;
+//    /// extern crate futures_timer;
+//    ///
+//    /// use std::time::Duration;
+//    /// use futures::prelude::*;
+//    /// use futures_timer::FutureExt;
+//    ///
+//    /// # fn long_future() -> futures::future::FutureResult<(), std::io::Error> {
+//    /// #   futures::future::ok(())
+//    /// # }
+//    /// #
+//    /// fn main() {
+//    ///     let future = long_future();
+//    ///     let timed_out = future.timeout(Duration::from_secs(1));
+//    ///
+//    ///     match timed_out.wait() {
+//    ///         Ok(item) => println!("got {:?} within enough time!", item),
+//    ///         Err(_) => println!("took too long to produce the item"),
+//    ///     }
+//    /// }
+//    /// ```
+//    fn timeout(self, dur: Duration) -> Timeout<Self>
 //        where Self::Error: From<io::Error>,
 //    {
-//        TimeoutStream {
+//        Timeout {
 //            timeout: Delay::new(dur),
-//            dur,
-//            stream: self,
+//            future: self,
+//        }
+//    }
+
+//    /// Creates a new future which will resolve no later than `at` specified.
+//    ///
+//    /// This method is otherwise equivalent to the `timeout` method except that
+//    /// it tweaks the moment at when the timeout elapsed to being specified with
+//    /// an absolute value rather than a relative one. For more documentation see
+//    /// the `timeout` method.
+//    fn timeout_at(self, at: Instant) -> Timeout<Self>
+//        where Self::Error: From<io::Error>,
+//    {
+//        Timeout {
+//            timeout: Delay::new_at(at),
+//            future: self,
 //        }
 //    }
 //}
 
-// impl<S: Stream> StreamExt for S {}
+//impl<F: TryFuture> FutureExt for F {}
 
-// /// Stream returned by the `StreamExt::timeout` method.
-// pub struct TimeoutStream<S> {
-//     timeout: Delay,
-//     dur: Duration,
-//     stream: S,
-// }
+///// Future returned by the `FutureExt::timeout` method.
+//pub struct Timeout<F: TryFuture> {
+//    future: F,
+//    timeout: Delay,
+//}
 
-// impl<S> Stream for TimeoutStream<S>
-//     where S: TryStream,
-//           S::Error: From<io::Error>,
-// {
-//     type Item = S::Item;
-//     type Error = S::Error;
+//impl<F: TryFuture> Timeout<F> {
+//    unsafe_pinned!(future: F);
+//}
 
-//     fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
-//         match self.stream.poll() {
-//             Ok(Poll::Pending) => {}
-//             other => {
-//                 self.timeout.reset(self.dur);
-//                 return other
-//             }
-//         }
+//impl<F> Future for Timeout<F>
+//    where F: TryFuture,
+//          F::Error: From<io::Error>,
+//{
+//    type Output = Result<F::Ok, F::Error>;
 
-//         if self.timeout.poll()?.is_ready() {
-//             self.timeout.reset(self.dur);
-//             Err(io::Error::new(io::ErrorKind::TimedOut, "stream item timed out").into())
-//         } else {
-//             Ok(Poll::Pending)
-//         }
-//     }
-// }
+//    fn poll(mut self: Pin<&mut Self>, mut cx: &mut Context<'_>) -> Poll<Self::Output> {
+//        match self.future().poll(&cx) {
+//            Poll::Pending => {}
+//            other => return Poll::Ready(Ok(other))
+//        }
+
+//        if self.timeout.poll()?.is_ready() {
+//            let err = Err(io::Error::new(io::ErrorKind::TimedOut, "future timed out").into());
+//            Poll::Ready(err)
+//        } else {
+//            Poll::Pending
+//        }
+//    }
+//}
+
+/////// An extension trait for streams which provides convenient accessors for
+/////// timing out execution and such.
+////pub trait StreamExt: Stream + Sized {
+
+////    /// Creates a new stream which will take at most `dur` time to yield each
+////    /// item of the stream.
+////    ///
+////    /// This combinator creates a new stream which wraps the receiving stream
+////    /// in a timeout-per-item. The stream returned will resolve in at most
+////    /// `dur` time for each item yielded from the stream. The first item's timer
+////    /// starts when this method is called.
+////    ///
+////    /// If a stream's item completes before `dur` elapses then the timer will be
+////    /// reset for the next item. If the timeout elapses, however, then an error
+////    /// will be yielded on the stream and the timer will be reset.
+////    fn timeout(self, dur: Duration) -> TimeoutStream<Self>
+////        where Self::Error: From<io::Error>,
+////    {
+////        TimeoutStream {
+////            timeout: Delay::new(dur),
+////            dur,
+////            stream: self,
+////        }
+////    }
+////}
+
+//// impl<S: Stream> StreamExt for S {}
+
+//// /// Stream returned by the `StreamExt::timeout` method.
+//// pub struct TimeoutStream<S> {
+////     timeout: Delay,
+////     dur: Duration,
+////     stream: S,
+//// }
+
+//// impl<S> Stream for TimeoutStream<S>
+////     where S: TryStream,
+////           S::Error: From<io::Error>,
+//// {
+////     type Item = S::Item;
+////     type Error = S::Error;
+
+////     fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+////         match self.stream.poll() {
+////             Ok(Poll::Pending) => {}
+////             other => {
+////                 self.timeout.reset(self.dur);
+////                 return other
+////             }
+////         }
+
+////         if self.timeout.poll()?.is_ready() {
+////             self.timeout.reset(self.dur);
+////             Err(io::Error::new(io::ErrorKind::TimedOut, "stream item timed out").into())
+////         } else {
+////             Ok(Poll::Pending)
+////         }
+////     }
+//// }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -3,8 +3,8 @@
 use std::time::{Duration, Instant};
 use std::io;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use futures::task::{Context, Poll};
 use futures::prelude::*;
 
 use crate::Delay;

--- a/src/global.rs
+++ b/src/global.rs
@@ -3,9 +3,11 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::Context;
-use std::task::{RawWaker, Waker};
+use std::task::{RawWaker, Waker, RawWakerVTable};
 use std::thread;
 use std::time::Instant;
+use std::future::Future;
+use std::mem::{self, ManuallyDrop};
 
 use crate::{Timer, TimerHandle};
 
@@ -51,18 +53,35 @@ impl Drop for HelperThread {
     }
 }
 
-fn run(timer: Timer, done: Arc<AtomicBool>) {
-    let mut timer = Pin::new(&mut timer);
-    let me = Arc::new(ThreadUnpark {
+fn run(mut timer: Timer, done: Arc<AtomicBool>) {
+    let me = Arc::into_raw(Arc::new(ThreadUnpark {
         thread: thread::current(),
-    });
-    let waker = unsafe { Waker::from_raw(RawWaker::new(me)) };
+    }));
+
+    unsafe fn raw_clone(ptr: *const ()) -> RawWaker {
+        let me = ManuallyDrop::new(Arc::from_raw(ptr as *const ThreadUnpark));
+        mem::forget(me.clone());
+        RawWaker::new(ptr, &VTABLE)
+    }
+    unsafe fn raw_wake(ptr: *const ()) {
+        let me = Arc::from_raw(ptr as *const ThreadUnpark);
+        me.thread.unpark()
+    }
+    unsafe fn raw_wake_by_ref(ptr: *const ()) {
+        let me = ManuallyDrop::new(Arc::from_raw(ptr as *const ThreadUnpark));
+        me.thread.unpark()
+    }
+    unsafe fn raw_drop(ptr: *const ()) {
+        Arc::from_raw(ptr as *const ThreadUnpark);
+    }
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(raw_clone, raw_wake, raw_wake_by_ref, raw_drop);
+    let waker = unsafe { Waker::from_raw(RawWaker::new(me as *const (), &VTABLE)) };
     let mut cx = Context::from_waker(&waker);
 
     while !done.load(Ordering::SeqCst) {
-        drop(timer.poll(cx));
-        timer.get_mut().advance();
-        match timer.get_mut().next_event() {
+        drop(Pin::new(&mut timer).poll(&mut cx));
+        Pin::new(&mut timer).get_mut().advance();
+        match Pin::new(&mut timer).get_mut().next_event() {
             // Ok, block for the specified time
             Some(when) => {
                 let now = Instant::now();

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,12 +1,12 @@
 use std::io;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
 
 use futures::executor::{spawn, Notify};
 
-use {TimerHandle, Timer};
+use crate::{Timer, TimerHandle};
 
 pub struct HelperThread {
     thread: Option<thread::JoinHandle<()>>,
@@ -52,9 +52,9 @@ impl Drop for HelperThread {
 
 fn run(timer: Timer, done: Arc<AtomicBool>) {
     let mut timer = spawn(timer);
-	let me = Arc::new(ThreadUnpark {
-		thread: thread::current(),
-	});
+    let me = Arc::new(ThreadUnpark {
+        thread: thread::current(),
+    });
     while !done.load(Ordering::SeqCst) {
         drop(timer.poll_future_notify(&me, 0));
         timer.get_mut().advance();

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -61,8 +61,8 @@ impl Interval {
 impl Stream for Interval {
     type Item = ();
 
-    fn poll_next(mut self: Pin<&mut Self>, mut cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if self.delay().poll(cx).is_pending() {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if Pin::new(&mut *self).delay().poll(cx).is_pending() {
             return Poll::Pending;
         }
         let next = next_interval(delay::fires_at(&self.delay), Instant::now(), self.interval);

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -60,13 +60,13 @@ impl Stream for Interval {
 
     fn poll(&mut self) -> Poll<Option<()>, io::Error> {
         if self.delay.poll()?.is_not_ready() {
-            return Ok(Async::NotReady)
+            return Ok(Poll::Pending)
         }
         let next = next_interval(delay::fires_at(&self.delay),
                                  Instant::now(),
                                  self.interval);
         self.delay.reset_at(next);
-        Ok(Async::Ready(Some(())))
+        Ok(Poll::Ready(Some(())))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ use arc_list::{ArcList, Node};
 use heap::{Heap, Slot};
 
 mod arc_list;
-pub mod ext;
+// pub mod ext;
 mod global;
 mod heap;
 // pub use ext::FutureExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,10 @@ use arc_list::{ArcList, Node};
 use heap::{Heap, Slot};
 
 mod arc_list;
-// pub mod ext;
 mod global;
 mod heap;
+
+// pub mod ext;
 // pub use ext::FutureExt;
 
 /// A "timer heap" used to power separately owned instances of `Delay` and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,27 +7,23 @@
 //!
 //! Basic usage of this crate is relatively simple:
 //!
-//! ```
-//! # extern crate futures;
-//! # extern crate futures_timer;
-//! # fn main() {
+//! ```no_run
+//! # #![feature(async_await)]
+//! # #[runtime::main]
+//! # async fn main() {
 //! use std::time::Duration;
 //! use futures_timer::Delay;
 //! use futures::prelude::*;
 //!
-//! let dur = Duration::from_secs(3);
-//! let fires_in_three_seconds = Delay::new(dur)
-//!     .map(|()| println!("prints three seconds later"));
-//! // spawn or use the future above
+//! let now = Delay::new(Duration::from_secs(3)).await;
+//! println!("waited for 3 secs");
 //! # }
 //! ```
 //!
 //! In addition to a one-shot future you can also create a stream of delayed
 //! notifications with the `Interval` type:
 //!
-//! ```
-//! # extern crate futures;
-//! # extern crate futures_timer;
+//! ```no_run
 //! # fn main() {
 //! use std::time::Duration;
 //! use futures_timer::Interval;

--- a/tests/interval.rs
+++ b/tests/interval.rs
@@ -1,26 +1,28 @@
-// extern crate futures;
-// extern crate futures_timer;
+#![feature(async_await)]
 
-// use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
+use std::error::Error;
 
-// use futures::prelude::*;
-// use futures_timer::Interval;
+use futures::prelude::*;
+use futures_timer::Interval;
 
-// #[test]
-// fn single() {
-//     let dur = Duration::from_millis(10);
-//     let start = Instant::now();
-//     let interval = Interval::new(dur);
-//     interval.take(1).collect().wait().unwrap();
-//     assert!(start.elapsed() >= dur);
-// }
+#[runtime::test]
+async fn single() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
+    let dur = Duration::from_millis(10);
+    let start = Instant::now();
+    let interval = Interval::new(dur);
+    interval.take(1).collect::<Vec<()>>().await;
+    assert!(start.elapsed() >= dur);
+    Ok(())
+}
 
-// #[test]
-// fn two_times() {
-//     let dur = Duration::from_millis(10);
-//     let start = Instant::now();
-//     let interval = Interval::new(dur);
-//     let result = interval.take(2).collect().wait().unwrap();
-//     assert!(start.elapsed() >= dur*2);
-//     assert_eq!(result, vec![(), ()]);
-// }
+#[runtime::test]
+async fn two_times() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
+    let dur = Duration::from_millis(10);
+    let start = Instant::now();
+    let interval = Interval::new(dur);
+    let result = interval.take(2).collect::<Vec<()>>().await;
+    assert!(start.elapsed() >= dur * 2);
+    assert_eq!(result, vec![(), ()]);
+    Ok(())
+}

--- a/tests/interval.rs
+++ b/tests/interval.rs
@@ -1,26 +1,26 @@
-extern crate futures;
-extern crate futures_timer;
+// extern crate futures;
+// extern crate futures_timer;
 
-use std::time::{Instant, Duration};
+// use std::time::{Instant, Duration};
 
-use futures::prelude::*;
-use futures_timer::Interval;
+// use futures::prelude::*;
+// use futures_timer::Interval;
 
-#[test]
-fn single() {
-    let dur = Duration::from_millis(10);
-    let start = Instant::now();
-    let interval = Interval::new(dur);
-    interval.take(1).collect().wait().unwrap();
-    assert!(start.elapsed() >= dur);
-}
+// #[test]
+// fn single() {
+//     let dur = Duration::from_millis(10);
+//     let start = Instant::now();
+//     let interval = Interval::new(dur);
+//     interval.take(1).collect().wait().unwrap();
+//     assert!(start.elapsed() >= dur);
+// }
 
-#[test]
-fn two_times() {
-    let dur = Duration::from_millis(10);
-    let start = Instant::now();
-    let interval = Interval::new(dur);
-    let result = interval.take(2).collect().wait().unwrap();
-    assert!(start.elapsed() >= dur*2);
-    assert_eq!(result, vec![(), ()]);
-}
+// #[test]
+// fn two_times() {
+//     let dur = Duration::from_millis(10);
+//     let start = Instant::now();
+//     let interval = Interval::new(dur);
+//     let result = interval.take(2).collect().wait().unwrap();
+//     assert!(start.elapsed() >= dur*2);
+//     assert_eq!(result, vec![(), ()]);
+// }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -59,10 +59,10 @@ fn drop_timer_wakes() {
     let mut t = Some(t);
     assert!(future::poll_fn(|| {
         match timeout.poll() {
-            Ok(Async::NotReady) => {}
+            Ok(Poll::Pending) => {}
             other => return other,
         }
         drop(t.take());
-        Ok(Async::NotReady)
+        Ok(Poll::Pending)
     }).wait().is_err());
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,68 +1,69 @@
-extern crate futures;
-extern crate futures_timer;
-
-use std::time::{Instant, Duration};
+#![feature(async_await)]
+use std::time::{Duration, Instant};
 
 use futures::future;
 use futures::prelude::*;
-use futures_timer::{Timer, Delay};
+use futures_timer::{Delay, Timer};
+use std::task::Poll;
 
 fn far_future() -> Instant {
     Instant::now() + Duration::new(5000, 0)
 }
 
-#[test]
-fn works() {
+#[runtime::test]
+async fn works() {
     let i = Instant::now();
     let dur = Duration::from_millis(100);
-    let d = Delay::new(dur);
-    d.wait().unwrap();
-    assert!(i.elapsed() > dur);
+    let d = Delay::new(dur).await;
+    assert!(dbg!(i.elapsed() > dur));
 }
 
-#[test]
-fn error_after_inert() {
-    let t = Timer::new();
-    let handle = t.handle();
-    drop(t);
-    assert!(Delay::new_handle(far_future(), handle).poll().is_err());
-}
+// #[runtime::test]
+// async fn error_after_inert() {
+//     let t = Timer::new();
+//     let handle = t.handle();
+//     drop(t);
+//     assert!(Delay::new_handle(far_future(), handle).poll().is_err());
+// }
 
-#[test]
-fn drop_makes_inert() {
-    let t = Timer::new();
-    let handle = t.handle();
-    let timeout = Delay::new_handle(far_future(), handle);
-    drop(t);
-    assert!(timeout.wait().is_err());
-}
+// #[runtime::test]
+// async fn drop_makes_inert() {
+//     let t = Timer::new();
+//     let handle = t.handle();
+//     let timeout = Delay::new_handle(far_future(), handle);
+//     drop(t);
+//     let res = timeout.await;
+//     assert!(res.is_err());
+// }
 
-#[test]
-fn reset() {
-    let i = Instant::now();
-    let dur = Duration::from_millis(100);
-    let mut d = Delay::new(dur);
-    future::poll_fn(|| d.poll()).wait().unwrap();
-    assert!(i.elapsed() > dur);
+// #[test]
+// fn reset() {
+//     let i = Instant::now();
+//     let dur = Duration::from_millis(100);
+//     let mut d = Delay::new(dur);
+//     future::poll_fn(|| d.poll()).wait().unwrap();
+//     assert!(i.elapsed() > dur);
 
-    let i = Instant::now();
-    d.reset(dur);
-    future::poll_fn(|| d.poll()).wait().unwrap();
-    assert!(i.elapsed() > dur);
-}
+//     let i = Instant::now();
+//     d.reset(dur);
+//     future::poll_fn(|| d.poll()).wait().unwrap();
+//     assert!(i.elapsed() > dur);
+// }
 
-#[test]
-fn drop_timer_wakes() {
-    let t = Timer::new();
-    let handle = t.handle();
-    let mut timeout = Delay::new_handle(far_future(), handle);
-    let mut t = Some(t);
-    assert!(future::poll_fn(|| {
-        match timeout.poll() {
-            Ok(Poll::Pending) => {}
-            other => return other,
-        }
-        drop(t.take());
-        Ok(Poll::Pending)
-    }).wait().is_err());
-}
+// #[test]
+// fn drop_timer_wakes() {
+//     let t = Timer::new();
+//     let handle = t.handle();
+//     let mut timeout = Delay::new_handle(far_future(), handle);
+//     let mut t = Some(t);
+//     assert!(future::poll_fn(|| {
+//         match timeout.poll() {
+//             Ok(Poll::Pending) => {}
+//             other => return other,
+//         }
+//         drop(t.take());
+//         Ok(Poll::Pending)
+//     })
+//     .wait()
+//     .is_err());
+// }

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,25 +1,23 @@
-// extern crate futures;
-// extern crate futures_timer;
+#![feature(async_await)]
 
-// use std::time::{Instant, Duration};
+use std::time::{Instant, Duration};
+use std::error::Error;
 
-// use futures::prelude::*;
-// use futures_timer::Delay;
+use futures_timer::Delay;
 
-// #[test]
-// fn smoke() {
-//     let dur = Duration::from_millis(10);
-//     let start = Instant::now();
-//     let timeout = Delay::new(dur);
-//     timeout.wait().unwrap();
-//     assert!(start.elapsed() >= (dur / 2));
-// }
+#[runtime::test]
+async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
+    let dur = Duration::from_millis(10);
+    let start = Instant::now();
+    Delay::new(dur).await?;
+    assert!(start.elapsed() >= (dur / 2));
+    Ok(())
+}
 
-// #[test]
-// fn two() {
-//     let dur = Duration::from_millis(10);
-//     let timeout = Delay::new(dur);
-//     timeout.wait().unwrap();
-//     let timeout = Delay::new(dur);
-//     timeout.wait().unwrap();
-// }
+#[runtime::test]
+async fn two() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
+    let dur = Duration::from_millis(10);
+    Delay::new(dur).await?;
+    Delay::new(dur).await?;
+    Ok(())
+}

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,25 +1,25 @@
-extern crate futures;
-extern crate futures_timer;
+// extern crate futures;
+// extern crate futures_timer;
 
-use std::time::{Instant, Duration};
+// use std::time::{Instant, Duration};
 
-use futures::prelude::*;
-use futures_timer::Delay;
+// use futures::prelude::*;
+// use futures_timer::Delay;
 
-#[test]
-fn smoke() {
-    let dur = Duration::from_millis(10);
-    let start = Instant::now();
-    let timeout = Delay::new(dur);
-    timeout.wait().unwrap();
-    assert!(start.elapsed() >= (dur / 2));
-}
+// #[test]
+// fn smoke() {
+//     let dur = Duration::from_millis(10);
+//     let start = Instant::now();
+//     let timeout = Delay::new(dur);
+//     timeout.wait().unwrap();
+//     assert!(start.elapsed() >= (dur / 2));
+// }
 
-#[test]
-fn two() {
-    let dur = Duration::from_millis(10);
-    let timeout = Delay::new(dur);
-    timeout.wait().unwrap();
-    let timeout = Delay::new(dur);
-    timeout.wait().unwrap();
-}
+// #[test]
+// fn two() {
+//     let dur = Duration::from_millis(10);
+//     let timeout = Delay::new(dur);
+//     timeout.wait().unwrap();
+//     let timeout = Delay::new(dur);
+//     timeout.wait().unwrap();
+// }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Migrate to the `std::Futures` API. Based on the excellent work in #10.

## Motivation and Context
This allows this crate to work with async/await.

Not everything from the `ext` trait works yet tho, but that shouldn't be a blocker to starting the migration.

## How Has This Been Tested?
Migrated all tests, and they pass!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
