### PR TITLE
get ext working + cleanup

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,169 +1,202 @@
-////! Extension traits for the standard `Stream` and `Future` traits.
+//! Extension traits for the standard `Stream` and `Future` traits.
 
-//use pin_utils::unsafe_pinned;
-//use std::io;
-//use std::pin::Pin;
-//use std::task::{Context, Poll};
-//use std::time::{Duration, Instant};
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 
-//use futures::prelude::*;
+use futures::prelude::*;
+use pin_utils::unsafe_pinned;
 
-//use crate::Delay;
+use crate::Delay;
 
-///// An extension trait for futures which provides convenient accessors for
-///// timing out execution and such.
-//pub trait FutureExt: TryFuture + Sized {
-//    /// Creates a new future which will take at most `dur` time to resolve from
-//    /// the point at which this method is called.
-//    ///
-//    /// This combinator creates a new future which wraps the receiving future
-//    /// in a timeout. The future returned will resolve in at most `dur` time
-//    /// specified (relative to when this function is called).
-//    ///
-//    /// If the future completes before `dur` elapses then the future will
-//    /// resolve with that item. Otherwise the future will resolve to an error
-//    /// once `dur` has elapsed.
-//    ///
-//    /// # Examples
-//    ///
-//    /// ```no_run
-//    /// use std::time::Duration;
-//    /// use futures::prelude::*;
-//    /// use futures_timer::FutureExt;
-//    ///
-//    /// # fn long_future() -> futures::future::FutureResult<(), std::io::Error> {
-//    /// #     futures::future::ok(())
-//    /// # }
-//    /// #
-//    /// #[runtime::main]
-//    /// async fn main() {
-//    ///     let future = long_future();
-//    ///     let timed_out = future.timeout(Duration::from_secs(1));
-//    ///
-//    ///     match timed_out.await {
-//    ///         Ok(item) => println!("got {:?} within enough time!", item),
-//    ///         Err(_) => println!("took too long to produce the item"),
-//    ///     }
-//    /// }
-//    /// ```
-//    fn timeout(self, dur: Duration) -> Timeout<Self>
-//    where
-//        Self::Error: From<io::Error>,
-//    {
-//        Timeout {
-//            timeout: Delay::new(dur),
-//            future: self,
-//        }
-//    }
+/// An extension trait for futures which provides convenient accessors for
+/// timing out execution and such.
+pub trait FutureExt: TryFuture + Sized {
+    /// Creates a new future which will take at most `dur` time to resolve from
+    /// the point at which this method is called.
+    ///
+    /// This combinator creates a new future which wraps the receiving future
+    /// in a timeout. The future returned will resolve in at most `dur` time
+    /// specified (relative to when this function is called).
+    ///
+    /// If the future completes before `dur` elapses then the future will
+    /// resolve with that item. Otherwise the future will resolve to an error
+    /// once `dur` has elapsed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # #![feature(async_await)]
+    /// use std::time::Duration;
+    /// use futures::prelude::*;
+    /// use futures_timer::FutureExt;
+    ///
+    /// # fn long_future() -> impl TryFuture<Ok = (), Error = std::io::Error> {
+    /// #     futures::future::ok(())
+    /// # }
+    /// #
+    /// #[runtime::main]
+    /// async fn main() {
+    ///     let future = long_future();
+    ///     let timed_out = future.timeout(Duration::from_secs(1));
+    ///
+    ///     match timed_out.await {
+    ///         Ok(item) => println!("got {:?} within enough time!", item),
+    ///         Err(_) => println!("took too long to produce the item"),
+    ///     }
+    /// }
+    /// ```
+    fn timeout(self, dur: Duration) -> Timeout<Self>
+    where
+        Self::Error: From<io::Error>,
+    {
+        Timeout {
+            timeout: Delay::new(dur),
+            future: self,
+        }
+    }
 
-//    /// Creates a new future which will resolve no later than `at` specified.
-//    ///
-//    /// This method is otherwise equivalent to the `timeout` method except that
-//    /// it tweaks the moment at when the timeout elapsed to being specified with
-//    /// an absolute value rather than a relative one. For more documentation see
-//    /// the `timeout` method.
-//    fn timeout_at(self, at: Instant) -> Timeout<Self>
-//    where
-//        Self::Error: From<io::Error>,
-//    {
-//        Timeout {
-//            timeout: Delay::new_at(at),
-//            future: self,
-//        }
-//    }
-//}
+    /// Creates a new future which will resolve no later than `at` specified.
+    ///
+    /// This method is otherwise equivalent to the `timeout` method except that
+    /// it tweaks the moment at when the timeout elapsed to being specified with
+    /// an absolute value rather than a relative one. For more documentation see
+    /// the `timeout` method.
+    fn timeout_at(self, at: Instant) -> Timeout<Self>
+    where
+        Self::Error: From<io::Error>,
+    {
+        Timeout {
+            timeout: Delay::new_at(at),
+            future: self,
+        }
+    }
+}
 
-//impl<F: TryFuture> FutureExt for F {}
+impl<F: TryFuture> FutureExt for F {}
 
-///// Future returned by the `FutureExt::timeout` method.
-//pub struct Timeout<F: TryFuture> {
-//    future: F,
-//    timeout: Delay,
-//}
+/// Future returned by the `FutureExt::timeout` method.
+pub struct Timeout<F>
+where
+    F: TryFuture,
+    F::Error: From<io::Error>,
+{
+    future: F,
+    timeout: Delay,
+}
 
-//impl<F: TryFuture> Timeout<F> {
-//    unsafe_pinned!(future: F);
-//}
+impl<F> Timeout<F>
+where
+    F: TryFuture,
+    F::Error: From<io::Error>,
+{
+    unsafe_pinned!(future: F);
+    unsafe_pinned!(timeout: Delay);
+}
 
-//impl<F> Future for Timeout<F>
-//where
-//    F: TryFuture,
-//    F::Error: From<io::Error>,
-//{
-//    type Output = Result<F::Ok, F::Error>;
+impl<F> Future for Timeout<F>
+where
+    F: TryFuture,
+    F::Error: From<io::Error>,
+{
+    type Output = Result<F::Ok, F::Error>;
 
-//    fn poll(mut self: Pin<&mut Self>, mut cx: &mut Context<'_>) -> Poll<Self::Output> {
-//        match self.future.poll(cx) {
-//            Poll::Pending => {}
-//            other => return Poll::Ready(Ok(other)),
-//        }
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.as_mut().future().try_poll(cx) {
+            Poll::Pending => {}
+            other => return other,
+        }
 
-//        if Pin::new(&mut self.timeout).poll(cx)?.is_ready() {
-//            let err = Err(io::Error::new(io::ErrorKind::TimedOut, "future timed out").into());
-//            Poll::Ready(err)
-//        } else {
-//            Poll::Pending
-//        }
-//    }
-//}
+        if self.timeout().poll(cx).is_ready() {
+            let err = Err(io::Error::new(io::ErrorKind::TimedOut, "future timed out").into());
+            Poll::Ready(err)
+        } else {
+            Poll::Pending
+        }
+    }
+}
 
-///// An extension trait for streams which provides convenient accessors for
-///// timing out execution and such.
-//pub trait StreamExt: Stream + Sized {
-//    /// Creates a new stream which will take at most `dur` time to yield each
-//    /// item of the stream.
-//    ///
-//    /// This combinator creates a new stream which wraps the receiving stream
-//    /// in a timeout-per-item. The stream returned will resolve in at most
-//    /// `dur` time for each item yielded from the stream. The first item's timer
-//    /// starts when this method is called.
-//    ///
-//    /// If a stream's item completes before `dur` elapses then the timer will be
-//    /// reset for the next item. If the timeout elapses, however, then an error
-//    /// will be yielded on the stream and the timer will be reset.
-//    fn timeout(self, dur: Duration) -> TimeoutStream<Self>
-//    where
-//        Self::Error: From<io::Error>,
-//    {
-//        TimeoutStream {
-//            timeout: Delay::new(dur),
-//            dur,
-//            stream: self,
-//        }
-//    }
-//}
+/// An extension trait for streams which provides convenient accessors for
+/// timing out execution and such.
+pub trait StreamExt: TryStream + Sized {
+    /// Creates a new stream which will take at most `dur` time to yield each
+    /// item of the stream.
+    ///
+    /// This combinator creates a new stream which wraps the receiving stream
+    /// in a timeout-per-item. The stream returned will resolve in at most
+    /// `dur` time for each item yielded from the stream. The first item's timer
+    /// starts when this method is called.
+    ///
+    /// If a stream's item completes before `dur` elapses then the timer will be
+    /// reset for the next item. If the timeout elapses, however, then an error
+    /// will be yielded on the stream and the timer will be reset.
+    fn timeout(self, dur: Duration) -> TimeoutStream<Self>
+    where
+        Self::Error: From<io::Error>,
+    {
+        TimeoutStream {
+            timeout: Delay::new(dur),
+            dur,
+            stream: self,
+        }
+    }
+}
 
-//impl<S: Stream> StreamExt for S {}
+impl<S: TryStream> StreamExt for S {}
 
-///// Stream returned by the `StreamExt::timeout` method.
-//pub struct TimeoutStream<S> {
-//    timeout: Delay,
-//    dur: Duration,
-//    stream: S,
-//}
+/// Stream returned by the `StreamExt::timeout` method.
+pub struct TimeoutStream<S>
+where
+    S: TryStream,
+    S::Error: From<io::Error>,
+{
+    timeout: Delay,
+    dur: Duration,
+    stream: S,
+}
 
-//impl<S> Stream for TimeoutStream<S>
-//where
-//    S: TryStream,
-//    S::Error: From<io::Error>,
-//{
-//    type Item = S::Item;
-//    type Error = S::Error;
+impl<S> TimeoutStream<S>
+where
+    S: TryStream,
+    S::Error: From<io::Error>,
+{
+    unsafe_pinned!(timeout: Delay);
+    unsafe_pinned!(stream: S);
+}
 
-//    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
-//        match self.stream.poll() {
-//            Ok(Poll::Pending) => {}
-//            other => {
-//                self.timeout.reset(self.dur);
-//                return other;
-//            }
-//        }
+impl<S> TryStream for TimeoutStream<S>
+where
+    S: TryStream,
+    S::Error: From<io::Error>,
+{
+    type Ok = S::Ok;
+    type Error = S::Error;
 
-//        if self.timeout.poll()?.is_ready() {
-//            self.timeout.reset(self.dur);
-//            Err(io::Error::new(io::ErrorKind::TimedOut, "stream item timed out").into())
-//        } else {
-//            Ok(Poll::Pending)
-//        }
-//    }
-//}
+    fn try_poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Ok, Self::Error>>> {
+        let dur = self.dur;
+
+        let r = self.as_mut().stream().try_poll_next(cx);
+        match r {
+            Poll::Pending => {}
+            other => {
+                self.as_mut().timeout().reset(dur);
+                return other;
+            }
+        }
+
+        if self.as_mut().timeout().poll(cx).is_ready() {
+            self.as_mut().timeout().reset(dur);
+            Poll::Ready(Some(Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "stream item timed out",
+            )
+            .into())))
+        } else {
+            Poll::Pending
+        }
+    }
+}

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,13 +1,13 @@
+use std::future::Future;
 use std::io;
+use std::mem::{self, ManuallyDrop};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::Context;
-use std::task::{RawWaker, Waker, RawWakerVTable};
+use std::task::{RawWaker, RawWakerVTable, Waker};
 use std::thread;
 use std::time::Instant;
-use std::future::Future;
-use std::mem::{self, ManuallyDrop};
 
 use crate::{Timer, TimerHandle};
 
@@ -74,7 +74,8 @@ fn run(mut timer: Timer, done: Arc<AtomicBool>) {
     unsafe fn raw_drop(ptr: *const ()) {
         Arc::from_raw(ptr as *const ThreadUnpark);
     }
-    static VTABLE: RawWakerVTable = RawWakerVTable::new(raw_clone, raw_wake, raw_wake_by_ref, raw_drop);
+    static VTABLE: RawWakerVTable =
+        RawWakerVTable::new(raw_clone, raw_wake, raw_wake_by_ref, raw_drop);
     let waker = unsafe { Waker::from_raw(RawWaker::new(me as *const (), &VTABLE)) };
     let mut cx = Context::from_waker(&waker);
 

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -72,15 +72,19 @@ impl<T: Ord> Heap<T> {
     pub fn pop(&mut self) -> Option<T> {
         self.assert_consistent();
         if self.items.len() == 0 {
-            return None
+            return None;
         }
-        let slot = Slot { idx: self.items[0].1 };
+        let slot = Slot {
+            idx: self.items[0].1,
+        };
         Some(self.remove(slot))
     }
 
     pub fn remove(&mut self, slot: Slot) -> T {
         self.assert_consistent();
-        let empty = SlabSlot::Empty { next: self.next_index };
+        let empty = SlabSlot::Empty {
+            next: self.next_index,
+        };
         let idx = match mem::replace(&mut self.index[slot.idx], empty) {
             SlabSlot::Full { value } => value,
             SlabSlot::Empty { .. } => panic!(),
@@ -97,14 +101,14 @@ impl<T: Ord> Heap<T> {
             }
         }
         self.assert_consistent();
-        return item
+        return item;
     }
 
     fn percolate_up(&mut self, mut idx: usize) -> usize {
         while idx > 0 {
             let parent = (idx - 1) / 2;
             if self.items[idx].0 >= self.items[parent].0 {
-                break
+                break;
             }
             let (a, b) = self.items.split_at_mut(idx);
             mem::swap(&mut a[parent], &mut b[0]);
@@ -112,7 +116,7 @@ impl<T: Ord> Heap<T> {
             set_index(&mut self.index, b[0].1, idx);
             idx = parent;
         }
-        return idx
+        return idx;
     }
 
     fn percolate_down(&mut self, mut idx: usize) -> usize {
@@ -124,7 +128,7 @@ impl<T: Ord> Heap<T> {
             match (self.items.get(left), self.items.get(right)) {
                 (Some(left), None) => {
                     if left.0 >= self.items[idx].0 {
-                        break
+                        break;
                     }
                 }
                 (Some(left), Some(right)) => {
@@ -135,7 +139,7 @@ impl<T: Ord> Heap<T> {
                     } else if right.0 < self.items[idx].0 {
                         swap_left = false;
                     } else {
-                        break
+                        break;
                     }
                 }
 
@@ -149,24 +153,30 @@ impl<T: Ord> Heap<T> {
                 self.items.split_at_mut(right)
             };
             mem::swap(&mut a[idx], &mut b[0]);
-            set_index(&mut self.index, a[idx].1,  idx);
+            set_index(&mut self.index, a[idx].1, idx);
             set_index(&mut self.index, b[0].1, a.len());
             idx = a.len();
         }
-        return idx
+        return idx;
     }
 
     fn assert_consistent(&self) {
         if !cfg!(assert_timer_heap_consistent) {
-            return
+            return;
         }
 
-        assert_eq!(self.items.len(), self.index.iter().filter(|slot| {
-            match **slot {
-                SlabSlot::Full { .. } => true,
-                SlabSlot::Empty { .. } => false,
-            }
-        }).count());
+        assert_eq!(
+            self.items.len(),
+            self.index
+                .iter()
+                .filter(|slot| {
+                    match **slot {
+                        SlabSlot::Full { .. } => true,
+                        SlabSlot::Empty { .. } => false,
+                    }
+                })
+                .count()
+        );
 
         for (i, &(_, j)) in self.items.iter().enumerate() {
             let index = match self.index[j] {
@@ -174,8 +184,10 @@ impl<T: Ord> Heap<T> {
                 SlabSlot::Empty { .. } => panic!(),
             };
             if index != i {
-                panic!("self.index[j] != i : i={} j={} self.index[j]={}",
-                       i, j, index);
+                panic!(
+                    "self.index[j] != i : i={} j={} self.index[j]={}",
+                    i, j, index
+                );
             }
         }
 
@@ -193,9 +205,7 @@ impl<T: Ord> Heap<T> {
     }
 }
 
-fn set_index<T>(slab: &mut Vec<SlabSlot<T>>,
-                slab_slot: usize,
-                val: T) {
+fn set_index<T>(slab: &mut Vec<SlabSlot<T>>, slab_slot: usize, val: T) {
     match slab[slab_slot] {
         SlabSlot::Full { ref mut value } => *value = val,
         SlabSlot::Empty { .. } => panic!(),
@@ -262,7 +272,7 @@ mod tests {
         for t in v {
             h.push(t);
         }
-        return h
+        return h;
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,8 @@ mod arc_list;
 mod global;
 mod heap;
 
-// pub mod ext;
-// pub use ext::FutureExt;
+pub mod ext;
+pub use ext::FutureExt;
 
 /// A "timer heap" used to power separately owned instances of `Delay` and
 /// `Interval`.

--- a/tests/interval.rs
+++ b/tests/interval.rs
@@ -1,13 +1,13 @@
 #![feature(async_await)]
 
-use std::time::{Duration, Instant};
 use std::error::Error;
+use std::time::{Duration, Instant};
 
 use futures::prelude::*;
 use futures_timer::Interval;
 
 #[runtime::test]
-async fn single() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
+async fn single() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
     let interval = Interval::new(dur);
@@ -17,7 +17,7 @@ async fn single() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
 }
 
 #[runtime::test]
-async fn two_times() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
+async fn two_times() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
     let interval = Interval::new(dur);

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,12 +1,12 @@
 #![feature(async_await)]
 
-use std::time::{Instant, Duration};
 use std::error::Error;
+use std::time::{Duration, Instant};
 
 use futures_timer::Delay;
 
 #[runtime::test]
-async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
+async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     let start = Instant::now();
     Delay::new(dur).await?;
@@ -15,7 +15,7 @@ async fn smoke() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
 }
 
 #[runtime::test]
-async fn two() -> Result<(), Box<dyn Error + Send + Sync + 'static>>{
+async fn two() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let dur = Duration::from_millis(10);
     Delay::new(dur).await?;
     Delay::new(dur).await?;


### PR DESCRIPTION
This is a cleanup patch - basically gets ext working again, runs `rustfmt` and gets the raw waker stuff ready to transition to `ArcWaker`.