### PR TITLE
impl Stream for TimeoutStream

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -167,18 +167,14 @@ where
     unsafe_pinned!(stream: S);
 }
 
-impl<S> TryStream for TimeoutStream<S>
+impl<S> Stream for TimeoutStream<S>
 where
     S: TryStream,
     S::Error: From<io::Error>,
 {
-    type Ok = S::Ok;
-    type Error = S::Error;
+    type Item = Result<S::Ok, S::Error>;
 
-    fn try_poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Ok, Self::Error>>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let dur = self.dur;
 
         let r = self.as_mut().stream().try_poll_next(cx);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`Stream<Item = Result<T, E>>` automatically implements `TryStream`. Also it can call `StreamExt`'s methods without `TryStream::into_stream`.

As far as I know, there is no advantage to implementing `TryStream` manually. (In my opinion, I think the purpose of `TryStream` is basically to make it easy to write a utility for `Stream<Item = Result<T, E>>` like `TryStreamExt`)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
