### PR TITLE
Add a name to the thread

### DIFF
--- a/src/global.rs
+++ b/src/global.rs
@@ -24,7 +24,9 @@ impl HelperThread {
         let timer_handle = timer.handle();
         let done = Arc::new(AtomicBool::new(false));
         let done2 = done.clone();
-        let thread = thread::Builder::new().spawn(move || run(timer, done2))?;
+        let thread = thread::Builder::new()
+            .name("futures-timer".to_owned())
+            .spawn(move || run(timer, done2))?;
 
         Ok(HelperThread {
             thread: Some(thread),


### PR DESCRIPTION
## Description

The background thread running the timer would now be named `futures-timer`.

## Motivation and Context

This makes it possible to easily identify the thread dedicated to `futures-timer` when debugging a Rust program that uses this library. The intention is that one generally purposefully ignores this thread while debugging.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
